### PR TITLE
feat/12-ux-add-bank-selectionn

### DIFF
--- a/src/components/BankCard.jsx
+++ b/src/components/BankCard.jsx
@@ -1,0 +1,30 @@
+import banksData from '../constants/bankData';
+import S from 'styled-components';
+
+function BankCard({bankNumber}) {
+
+const bankName = banksData[bankNumber]?.name ?? 'Nepostojeća banka';
+
+  return (
+  <BankCardWrapper>
+     <BankName>Ovaj račun pripada: {bankName}</BankName>
+  </BankCardWrapper>
+   )}
+
+const BankCardWrapper = S.div`
+display: flex;
+flex-direction: column;
+align-items:flex-start;
+margin-bottom: 0.3rem;
+overflow: hidden;
+`
+const BankName = S.p`line-height: 1.2em;
+font-family: Arial, Helvetica, sans-serif;
+font-size: 3mm;
+max-width: 100%;
+white-space: nowrap;
+overflow: hidden;
+text-overflow: ellipsis;
+`
+
+export default BankCard;

--- a/src/constants/bankData.js
+++ b/src/constants/bankData.js
@@ -1,0 +1,90 @@
+const banksData = {
+    105: {
+        name: 'AGROINDUSTRIJSKO KOMERCIJALNA  BANKA AIK BANKA, AD, BEOGRAD',
+        img: '',
+    },
+    
+     115: {
+        name: 'MOBI BANKA, AD, BEOGRAD',
+        img: '',
+    },
+    145: {
+        name: 'EXPOBANK,AD,BEOGRAD',
+        img: '',
+    },
+    155: {
+        name: 'HALKBANK, AD, BEOGRAD',
+        img: '',
+    },
+    160: {
+        name: 'BANCAINTESA,AD,BEOGRAD',
+        img: '',
+    },
+    165: {
+        name: 'ADDIKO BANK, AD, BEOGRAD',
+        img: '',
+    },
+    170: {
+        name: 'UNICREDIT BANK SRBIJA, AD, BEOGRAD',
+        img: '',
+    },
+    190: {
+        name: 'ALTA BANKA, AD, BEOGRAD',
+        img: '',
+    },
+    200: {
+        name: 'BANKA POSTANSKA  STEDIONICA, AD, BEOGRAD',
+        img: '',
+    },
+    205: {
+        name: 'NLB KOMERCIJALNABANKA,AD, BEOGRAD',
+        img: '',
+    },
+    220: {
+        name: 'PROCREDIT BANK, AD, BEOGRAD',
+        img: '',
+    },
+    250: {
+        name: 'EUROBANK DIREKTNA, AD, BEOGRAD',
+        img: '',
+    },
+    265: {
+        name: 'RAIFFEISEN BANKA, AD, BEOGRAD',
+        img: '',
+    },
+    295: {
+        name: 'SRPSKA BANKA, AD, BEOGRAD',
+        img: '',
+    },
+    325: {
+        name: 'OTP BANKA SRBIJA AKCIONARSKO  DRUSTVO NOVI SAD',
+        img: '',
+    },
+    330: {
+        name: 'RBA BANKA, AD, NOVI SAD',
+        img: '',
+    },
+    340: {
+        name: 'ERSTE BANK, AD, NOVI SAD',
+        img: '',
+    },
+    370: {
+        name: '3 BANKA, AD, NOVI SAD',
+        img: '',
+    },
+    375: {
+        name: 'API BANK, AD, BEOGRAD',
+        img: '',
+    },
+    380: {
+        name: 'MIRABANK, AD, BEOGRAD',
+        img: '',
+    },
+    385: {
+        name: 'BANK OF CHINA SRBIJA, AD, BEOGRAD - NOVI BEOGRAD',
+        img: '',
+    },
+
+};
+
+export default banksData;

--- a/src/pages/Payslip.jsx
+++ b/src/pages/Payslip.jsx
@@ -10,6 +10,7 @@ import { deviceBrakepoints } from '@config/device-brakepoints.jsx'
 import { useReducer } from 'react'
 import { useLocation } from 'react-router-dom'
 import Modelselect from '../components/Modelselect.jsx'
+import BankCard from '../components/BankCard.jsx'
 
 export const ModelCodeOptions = [
     { value: '97', label: '97' },
@@ -1064,6 +1065,7 @@ function Payslip() {
                         }
                     ]}
                 />
+                <BankCard bankNumber={state.bankNumber} />
                 <Modelselect
                     width={25}
                     label='Model'


### PR DESCRIPTION
Fixing issue
UX - Add selection of Serbian banks to display Bank Logo and primary color based on account number https://github.com/Code-for-Serbia/uplatnica/issues/12

Click on link to see video

[Uplatnica just bank name.webm](https://user-images.githubusercontent.com/37368862/231425998-e7874d64-4725-4975-9707-ef349657a9b0.webm)
